### PR TITLE
fix: move plugin when syncing

### DIFF
--- a/doc/balls.txt
+++ b/doc/balls.txt
@@ -194,7 +194,7 @@ TYPES                                                              *balls-types*
     • name (string)
     • lazy (boolean)
     • on_sync? (fun(self: |balls.Plugin|))
-    • path (fun(self: |balls.Plugin|): string)
+    • path (fun(self: |balls.Plugin|, lazy?: boolean): string)
     • installed (fun(self: |balls.Plugin|): boolean)
     • install (fun(self: |balls.Plugin))
     • update (fun(self: |balls.Plugin))

--- a/lua/balls.lua
+++ b/lua/balls.lua
@@ -187,11 +187,7 @@ end
 --- Syncs the list of registered plugins with the actually installed plugins on the system.
 function M.sync()
 	for _, plugin in pairs(_G.BALLS_PLUGINS) do
-		if plugin:installed() then
-			plugin:sync()
-		else
-			plugin:install()
-		end
+		plugin:sync()
 	end
 
 	M.clean()

--- a/plugin/balls.lua
+++ b/plugin/balls.lua
@@ -8,7 +8,7 @@
 ---
 --- @field on_sync? fun(self: balls.Plugin) Callback function to run anytime the plugin installs / updates.
 ---
---- @field path fun(): string Returns the local installation path of this plugin.
+--- @field path fun(self: balls.Plugin, lazy?: boolean): string Returns the local installation path of this plugin.
 --- @field installed fun(self: balls.Plugin): boolean Returns whether the plugin is installed.
 --- @field install fun(self: balls.Plugin) Installs this plugin locally.
 --- @field update fun(self: balls.Plugin) Updates this plugin.


### PR DESCRIPTION
There was a bug where a plugin wouldn't get deleted when syncing after changing the `lazy` flag. It was required to run `:BallsSync` twice for it to actually work correctly.

The logic has been altered to not delete the old plugin, but instead move it. The syncing logic has also been fixed so that a single `:BallsSync` actually does what it's supposed to do.